### PR TITLE
add Conn.WriteBulkBytes

### DIFF
--- a/redcon.go
+++ b/redcon.go
@@ -21,6 +21,8 @@ type Conn interface {
 	WriteString(str string)
 	// WriteBulk writes a bulk string to the client.
 	WriteBulk(bulk string)
+	// WriteBulkBytes writes bulk bytes to the client.
+	WriteBulkBytes(bulk []byte)
 	// WriteInt writes an integer to the client.
 	WriteInt(num int)
 	// WriteArray writes an array header. You must then write addtional
@@ -231,6 +233,9 @@ func (c *conn) WriteString(str string) {
 }
 func (c *conn) WriteBulk(bulk string) {
 	c.wr.WriteBulk(bulk)
+}
+func (c *conn) WriteBulkBytes(bulk []byte) {
+	c.wr.WriteBulkBytes(bulk)
 }
 func (c *conn) WriteInt(num int) {
 	c.wr.WriteInt(num)
@@ -482,6 +487,18 @@ func (w *writer) WriteBulk(bulk string) error {
 	w.b = append(w.b, []byte(strconv.FormatInt(int64(len(bulk)), 10))...)
 	w.b = append(w.b, '\r', '\n')
 	w.b = append(w.b, []byte(bulk)...)
+	w.b = append(w.b, '\r', '\n')
+	return nil
+}
+
+func (w *writer) WriteBulkBytes(bulk []byte) error {
+	if w.err != nil {
+		return w.err
+	}
+	w.b = append(w.b, '$')
+	w.b = append(w.b, []byte(strconv.FormatInt(int64(len(bulk)), 10))...)
+	w.b = append(w.b, '\r', '\n')
+	w.b = append(w.b, bulk...)
 	w.b = append(w.b, '\r', '\n')
 	return nil
 }

--- a/redcon_test.go
+++ b/redcon_test.go
@@ -196,6 +196,8 @@ func TestServer(t *testing.T) {
 					conn.WriteInt(100)
 				case "bulk":
 					conn.WriteBulk("bulk")
+				case "bulkbytes":
+					conn.WriteBulkBytes([]byte("bulkbytes"))
 				case "null":
 					conn.WriteNull()
 				case "err":
@@ -262,6 +264,13 @@ func TestServer(t *testing.T) {
 		}
 		if res != "$4\r\nbulk\r\n" {
 			t.Fatal("expecting bulk, got '%v'", res)
+		}
+		res, err = do("BULKBYTES\r\n")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res != "$9\r\nbulkbytes\r\n" {
+			t.Fatal("expecting bulkbytes, got '%v'", res)
 		}
 		res, err = do("INT\r\n")
 		if err != nil {


### PR DESCRIPTION
This commit adds a `Conn.WriteBulkBytes` function, to avoid the extra copy with `string` and `[]byte` conversion.