### PR TITLE
export ReadCommands method

### DIFF
--- a/redcon.go
+++ b/redcon.go
@@ -2,7 +2,6 @@
 package redcon
 
 import (
-	"bufio"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -623,7 +622,7 @@ func (w *Writer) WriteRaw(data []byte) {
 
 // Reader represent a reader for RESP or telnet commands.
 type Reader struct {
-	rd    *bufio.Reader
+	rd    io.Reader
 	buf   []byte
 	start int
 	end   int
@@ -633,7 +632,7 @@ type Reader struct {
 // NewReader returns a command reader which will read RESP or telnet commands.
 func NewReader(rd io.Reader) *Reader {
 	return &Reader{
-		rd:  bufio.NewReader(rd),
+		rd:  rd,
 		buf: make([]byte, 4096),
 	}
 }

--- a/redcon.go
+++ b/redcon.go
@@ -871,6 +871,11 @@ func (rd *Reader) readCommands(leftover *int) ([]Command, error) {
 	return rd.readCommands(leftover)
 }
 
+// ReadCommands reads multiple commands for pipeline mode.
+func (rd *Reader) ReadCommands() ([]Command, error) {
+	return rd.readCommands(nil)
+}
+
 // ReadCommand reads the next command.
 func (rd *Reader) ReadCommand() (Command, error) {
 	if len(rd.cmds) > 0 {

--- a/redcon.go
+++ b/redcon.go
@@ -523,6 +523,19 @@ type Command struct {
 	Time  int64
 }
 
+func (c Command) GetAllArgs() [][]byte {
+	if c.Args != nil {
+		return c.Args
+	}
+	n := len(c.marks) / 2
+	args := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		args[i] = c.Raw[c.marks[i*2]:c.marks[i*2+1]]
+	}
+	c.Args = args
+	return args
+}
+
 // GetArgs get args for zero allocations for args.
 func (c Command) GetArgs(i int) []byte {
 	if c.Args != nil {

--- a/redcon.go
+++ b/redcon.go
@@ -531,6 +531,15 @@ func (c Command) GetArgs(i int) []byte {
 	return c.Raw[c.marks[h]:c.marks[h+1]]
 }
 
+// GetArgCount get count of args.
+func (c Command) GetArgCount() int {
+	if c.Args != nil {
+		return len(c.Args)
+	}
+
+	return len(c.marks) / 2
+}
+
 // Server defines a server for clients for managing client connections.
 type Server struct {
 	mu      sync.Mutex

--- a/redcon.go
+++ b/redcon.go
@@ -18,6 +18,10 @@ var (
 	errTooMuchData            = errors.New("too much data")
 )
 
+var (
+	InitReaderBufferSize = 4096
+)
+
 type errProtocol struct {
 	msg string
 }
@@ -632,8 +636,9 @@ type Reader struct {
 // NewReader returns a command reader which will read RESP or telnet commands.
 func NewReader(rd io.Reader) *Reader {
 	return &Reader{
-		rd:  rd,
-		buf: make([]byte, 4096),
+		rd:   rd,
+		cmds: make([]Command, 0, 50),
+		buf:  make([]byte, InitReaderBufferSize),
 	}
 }
 
@@ -661,10 +666,11 @@ func parseInt(b []byte) (int, bool) {
 }
 
 func (rd *Reader) readCommands(leftover *int) ([]Command, error) {
-	var cmds []Command
+	var cmds = rd.cmds[:0]
 	b := rd.buf[rd.start:rd.end]
-	if rd.end-rd.start == 0 && len(rd.buf) > 4096 {
-		rd.buf = rd.buf[:4096]
+	if rd.end-rd.start == 0 && len(rd.buf) > InitReaderBufferSize {
+		//rd.buf = make([]byte, InitReaderBufferSize)
+		rd.buf = rd.buf[:InitReaderBufferSize]
 		rd.start = 0
 		rd.end = 0
 	}

--- a/redcon.go
+++ b/redcon.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 )
 
 var (
@@ -517,9 +518,9 @@ type Command struct {
 	// Raw is a encoded RESP message.
 	Raw []byte
 	// Args is a series of arguments that make up the command.
-	Args [][]byte
-
+	Args  [][]byte
 	marks []int
+	Time  int64
 }
 
 // GetArgs get args for zero allocations for args.
@@ -686,6 +687,7 @@ func parseInt(b []byte) (int, bool) {
 }
 
 func (rd *Reader) readCommands(leftover *int) ([]Command, error) {
+	start := time.Now().UnixNano()
 	var cmds = rd.cmds[:0]
 	b := rd.buf[rd.start:rd.end]
 	if rd.end-rd.start == 0 && len(rd.buf) > InitReaderBufferSize {
@@ -781,6 +783,7 @@ func (rd *Reader) readCommands(leftover *int) ([]Command, error) {
 							cmd.Args[i] = arg
 						}
 						cmd.Raw = wr.b
+						cmd.Time = start
 						cmds = append(cmds, cmd)
 					}
 					b = b[i+1:]
@@ -853,6 +856,7 @@ func (rd *Reader) readCommands(leftover *int) ([]Command, error) {
 						}
 
 						cmd.marks = marks
+						cmd.Time = start
 						cmds = append(cmds, cmd)
 						b = b[i+1:]
 						if len(b) > 0 {


### PR DESCRIPTION
I am using redcon.Reader to parse commands but redcon.Reader has not export the readCommands so I can't use it to read multiple commands in pipeline mode.

Could you export the ReadCommands method?