### PR TITLE
use a reusable slice for storing args in readcommands functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tidwall/redcon
 
-go 1.15
+go 1.19
 
 require (
 	github.com/tidwall/btree v1.1.0


### PR DESCRIPTION
Unsure if this is usable to you or users of your library since it only works on newer Go versions due to the use of Generics but I figured creating a PR for this wouldn't hurt.