### PR TITLE
fix: TestNextCommand

### DIFF
--- a/resp_test.go
+++ b/resp_test.go
@@ -199,7 +199,7 @@ func TestNextCommand(t *testing.T) {
 				}
 				fargs = append(fargs, args)
 			}
-			rbuf = append(rbuf[:0], data...)
+			rbuf = append([]byte{}, data...)
 		}
 		// compare final args to original
 		if len(plargs) != len(fargs) {
@@ -210,7 +210,7 @@ func TestNextCommand(t *testing.T) {
 				t.Fatalf("not equal size for item %v: %v != %v", i, len(plargs[i]), len(fargs[i]))
 			}
 			for j := 0; j < len(plargs[i]); j++ {
-				if !bytes.Equal(plargs[i][j], plargs[i][j]) {
+				if !bytes.Equal(plargs[i][j], fargs[i][j]) {
 					t.Fatalf("not equal for item %v:%v: %v != %v", i, j, len(plargs[i][j]), len(fargs[i][j]))
 				}
 			}


### PR DESCRIPTION
Since rbuf and data points to the same array, it could be the case that we corrupt our underlying data as we're copying into it. The fix is create a new slice.